### PR TITLE
Feature help support

### DIFF
--- a/PowerCommandParser/HelpText.cs
+++ b/PowerCommandParser/HelpText.cs
@@ -9,58 +9,58 @@ using System.Threading.Tasks;
 
 namespace PowerCommandParser
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
     public class DescriptionAttribute : Attribute
     {
         public string Text { get; set; }
         public string Summary { get; set; }
-		public DescriptionAttribute(){}
-		public DescriptionAttribute(string summary)
-		{
-			Summary = summary;
-		}
+        public DescriptionAttribute() { }
+        public DescriptionAttribute(string summary)
+        {
+            Summary = summary;
+        }
         public DescriptionAttribute(string summary, string text)
         {
-			Summary = summary;
+            Summary = summary;
             Text = text;
         }
     }
-	public class HelpText<T>
-	{
-		public string Name { get; set; }
-		private DescriptionAttribute Description => typeof(T).GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute;
+    public class HelpText<T>
+    {
+        public string Name { get; set; }
+        private DescriptionAttribute Description => typeof(T).GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute;
         public string ProgramName => typeof(T).Assembly.GetName().Name;
         public string Synopsis => Description?.Summary ?? ProgramName;
-		public string LongDescription => Description?.Text; 
-		private IEnumerable<PropertyInfo> OrderedProperties => typeof(T).GetProperties().OrderBy(p=>p.GetCustomAttributes().Min(a=>(a as PositionAttribute)?.Position) ?? int.MaxValue); 
-		public string GetSyntax()
-		{
-			var result = Name;
-			foreach (var parameter in OrderedProperties)
-			{
-				var positioned = parameter.GetCustomAttribute(typeof(PositionAttribute)) != null;
-				var required = parameter.GetCustomAttribute(typeof(RequiredAttribute)) != null;
-				var parameterType = parameter.PropertyType.ToString();
-				var parameterText = parameter.Name;
-				if (positioned)
-					parameterText = $"[{parameterText}]";
-					
-				parameterText+=$" [{parameterType}]";
-				if (!required)
-					parameterText = $"[{parameterText}]";
-					
-				result += " " + parameterText;
-			}
-			
-			return result;
-		}
-		
-		public string GetParameterHelp()
-		{
-			return string.Join("\n\n", OrderedProperties
-							.Select(p=>new {p,d = p.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute})
-							.Where(x=>x.d!=null)
-							.Select(x=>$"{x.p.Name}:\n {x.d.Summary}"));
-		}
-	}
+        public string LongDescription => Description?.Text;
+        private IEnumerable<PropertyInfo> OrderedProperties => typeof(T).GetProperties().OrderBy(p => p.GetCustomAttributes().Min(a => (a as PositionAttribute)?.Position) ?? int.MaxValue);
+        public string GetSyntax()
+        {
+            var result = Name;
+            foreach (var parameter in OrderedProperties)
+            {
+                var positioned = parameter.GetCustomAttribute(typeof(PositionAttribute)) != null;
+                var required = parameter.GetCustomAttribute(typeof(RequiredAttribute)) != null;
+                var parameterType = parameter.PropertyType.ToString();
+                var parameterText = parameter.Name;
+                if (positioned)
+                    parameterText = $"[{parameterText}]";
+
+                parameterText += $" {parameterType}";
+                if (!required)
+                    parameterText = $"[{parameterText}]";
+
+                result += " " + parameterText;
+            }
+
+            return result;
+        }
+
+        public string GetParameterHelp()
+        {
+            return string.Join("\n\n", OrderedProperties
+                            .Select(p => new { p, d = p.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute })
+                            .Where(x => x.d != null)
+                            .Select(x => $"{x.p.Name}:\n {x.d.Summary}"));
+        }
+    }
 }

--- a/PowerCommandParser/HelpText.cs
+++ b/PowerCommandParser/HelpText.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerCommandParser
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    public class DescriptionAttribute : Attribute
+    {
+        public string Text { get; set; }
+        public string Summary { get; set; }
+		public DescriptionAttribute(){}
+		public DescriptionAttribute(string summary)
+		{
+			Summary = summary;
+		}
+        public DescriptionAttribute(string summary, string text)
+        {
+			Summary = summary;
+            Text = text;
+        }
+    }
+	public class HelpText<T>
+	{
+		public string Name { get; set; }
+		private DescriptionAttribute Description => typeof(T).GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute;
+		public string Synopsis => Description.Summary;
+		public string LongDescription => Description.Text; 
+		private IEnumerable<PropertyInfo> OrderedProperties => typeof(T).GetProperties().OrderBy(p=>p.GetCustomAttributes().Min(a=>(a as PositionAttribute)?.Position) ?? int.MaxValue); 
+		public string GetSyntax()
+		{
+			var result = Name;
+			foreach (var parameter in OrderedProperties)
+			{
+				var positioned = parameter.GetCustomAttribute(typeof(PositionAttribute)) != null;
+				var required = parameter.GetCustomAttribute(typeof(RequiredAttribute)) != null;
+				var parameterType = parameter.PropertyType.ToString();
+				var parameterText = parameter.Name;
+				if (positioned)
+					parameterText = $"[{parameterText}]";
+					
+				parameterText+=$" [{parameterType}]";
+				if (!required)
+					parameterText = $"[{parameterText}]";
+					
+				result += " " + parameterText;
+			}
+			
+			return result;
+		}
+		
+		public string GetParameterHelp()
+		{
+			return string.Join("\n\n", OrderedProperties
+							.Select(p=>new {p,d = p.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute})
+							.Where(x=>x.d!=null)
+							.Select(x=>$"{x.p.Name}:\n {x.d.Summary}"));
+		}
+	}
+}

--- a/PowerCommandParser/HelpText.cs
+++ b/PowerCommandParser/HelpText.cs
@@ -29,8 +29,9 @@ namespace PowerCommandParser
 	{
 		public string Name { get; set; }
 		private DescriptionAttribute Description => typeof(T).GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute;
-		public string Synopsis => Description.Summary;
-		public string LongDescription => Description.Text; 
+        public string ProgramName => typeof(T).Assembly.GetName().Name;
+        public string Synopsis => Description?.Summary ?? ProgramName;
+		public string LongDescription => Description?.Text; 
 		private IEnumerable<PropertyInfo> OrderedProperties => typeof(T).GetProperties().OrderBy(p=>p.GetCustomAttributes().Min(a=>(a as PositionAttribute)?.Position) ?? int.MaxValue); 
 		public string GetSyntax()
 		{

--- a/PowerCommandParser/Parser.cs
+++ b/PowerCommandParser/Parser.cs
@@ -53,7 +53,10 @@ namespace PowerCommandParser
             {
                 return Convert.ChangeType(value, type);
             }
-            catch (InvalidCastException)
+            catch (Exception ex) 
+            when (ex is OverflowException 
+                || ex is FormatException 
+                || ex is InvalidCastException)
             {
                 if (type.IsEnum)
                 {
@@ -119,6 +122,23 @@ namespace PowerCommandParser
                 .ToList();
 
             var requiredArguments = properties.Where(p => p.GetCustomAttributes(false).Any(a => a is RequiredAttribute)).ToList();
+
+            //Check for help or version switches
+            foreach(var arg in args.Select(a=>a.ToLowerInvariant()))
+            {
+                if (arg == "--help")
+                {
+                    HelpText<T> helpText = new HelpText<T>();
+                    Console.WriteLine(helpText.Name);
+                    Console.WriteLine(helpText.Synopsis);
+                    Console.WriteLine(helpText.GetSyntax());
+                    Console.WriteLine(helpText.LongDescription);
+                    Console.WriteLine(helpText.GetParameterHelp());
+                    return null;
+                }
+            }
+
+
             for(int i = 0; i < args.Length; i++)
             {
                 if (args[i].StartsWith("--"))
@@ -127,16 +147,7 @@ namespace PowerCommandParser
                     var property = properties.SingleOrDefault(p => MatchesArgument(p, switchName));
                     if (property == null || !property.PropertyType.IsAssignableFrom(typeof(bool)))
                     {
-                        if (switchName.ToLowerInvariant() == "help")
-                        {
-                            HelpText<T> helpText = new HelpText<T>();
-                            Console.WriteLine(helpText.Name);
-                            Console.WriteLine(helpText.Synopsis);
-                            Console.WriteLine(helpText.GetSyntax());
-                            Console.WriteLine(helpText.LongDescription);
-                            Console.WriteLine(helpText.GetParameterHelp());
-                        }
-                        else if (outputErrors)
+                        if (outputErrors)
                                 Console.Error.WriteLine($"No switch named {switchName} was found in the application");
                         return null;
                     }
@@ -162,7 +173,17 @@ namespace PowerCommandParser
                             Console.Error.WriteLine($"No argument named {paramName} was found in the application");
                         return null;
                     }
-                    SetValue(property, result, args[++i]);
+                    try
+                    {
+                        SetValue(property, result, args[++i]);
+
+                    }
+                    catch (NotSupportedException ex)
+                    {
+                        if (outputErrors)
+                            Console.Error.WriteLine(ex.Message);
+                        return null;
+                    }
 
                     providedArguments.Add(paramName);
                     positionalArguments.RemoveAll(r => r.Name == property.Name);

--- a/PowerCommandParser/Parser.cs
+++ b/PowerCommandParser/Parser.cs
@@ -127,11 +127,21 @@ namespace PowerCommandParser
                     var property = properties.SingleOrDefault(p => MatchesArgument(p, switchName));
                     if (property == null || !property.PropertyType.IsAssignableFrom(typeof(bool)))
                     {
-                        if (outputErrors)
-                            Console.Error.WriteLine($"No switch named {switchName} was found in the application");
+                        if (switchName.ToLowerInvariant() == "help")
+                        {
+                            HelpText<T> helpText = new HelpText<T>();
+                            Console.WriteLine(helpText.Name);
+                            Console.WriteLine(helpText.Synopsis);
+                            Console.WriteLine(helpText.GetSyntax());
+                            Console.WriteLine(helpText.LongDescription);
+                            Console.WriteLine(helpText.GetParameterHelp());
+                        }
+                        else if (outputErrors)
+                                Console.Error.WriteLine($"No switch named {switchName} was found in the application");
                         return null;
                     }
-                    property.SetValue(result, true);
+                    else
+                        property.SetValue(result, true);
 
                     providedArguments.Add(switchName);
                     positionalArguments.RemoveAll(r => r.Name == property.Name);

--- a/PowerCommandParser/PowerCommandParser.csproj
+++ b/PowerCommandParser/PowerCommandParser.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HelpText.cs" />
     <Compile Include="Parser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/PowerCommandParser/Properties/AssemblyInfo.cs
+++ b/PowerCommandParser/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.*")]
+[assembly: AssemblyVersion("0.3.*")]
 //[assembly: AssemblyFileVersion("0.1.*")]

--- a/UnitTests/HelpTests.cs
+++ b/UnitTests/HelpTests.cs
@@ -79,8 +79,7 @@ namespace UnitTests
         {
             string output;
             var result = TestHelper.ParseArguments<ClassWithHelp>("--help", out output);
-
-            //Assert.IsTrue(output.Contains("UnitTests.exe"));
+            
             Assert.IsTrue(output.Contains("[Name System.String]"));
             Assert.IsTrue(output.Contains("[Value System.Int32]"));
             Assert.IsTrue(output.Contains("Required System.String"));

--- a/UnitTests/HelpTests.cs
+++ b/UnitTests/HelpTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class HelpTests
+    {
+        public class NormalNoHelp
+        {
+            public int Value { get; set; }
+            public string Name { get; set; }
+        }
+        public class ClassWithHelp
+        {
+            [PowerCommandParser.Description("A name to use")]
+            public string Name { get; set; }
+        }
+        [TestMethod]
+        public void HelpDetected()
+        {
+            var oldOut = Console.Out;
+            var stringWriter = new System.IO.StringWriter();
+            Console.SetOut(stringWriter);
+            var result = PowerCommandParser.Parser.ParseArguments<NormalNoHelp>(TestHelper.CmdLineEntryParser("--help"));
+            Console.Out.Flush();
+            Console.SetOut(oldOut);
+
+            Assert.IsNull(result);
+            Assert.IsFalse(stringWriter.ToString().Contains("No switch named "));
+        }
+    }
+}

--- a/UnitTests/HelpTests.cs
+++ b/UnitTests/HelpTests.cs
@@ -16,10 +16,10 @@ namespace UnitTests
             public int Value { get; set; }
             public string Name { get; set; }
         }
-        [PowerCommandParser.Description("Sample usage of help attributes")]
+        [PowerCommandParser.Description("Sample usage of help attributes", "Detailed class information")]
         public class ClassWithHelp
         {
-            [PowerCommandParser.Description("A name to use")]
+            [PowerCommandParser.Description("A name to use","Detailed Information")]
             public string Name { get; set; }
             public int Value { get; set; }
             [Required]
@@ -88,6 +88,14 @@ namespace UnitTests
             Assert.IsTrue(output.Contains("[PositionalAndRequired] System.Single"));
             Assert.IsFalse(output.Contains("[[PositionalAndRequired] System.Single]"));
             Assert.IsTrue(output.IndexOf("[[Positional] System.Int32]") < output.IndexOf("[PositionalAndRequired] System.Single"));
+        }
+        public void ShowsDetailedDescription()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<ClassWithHelp>("--help", out output);
+
+            Assert.IsTrue(output.Contains("Detailed class information"));
+            Assert.IsTrue(output.Contains("Detailed information"));
         }
     }
 }

--- a/UnitTests/HelpTests.cs
+++ b/UnitTests/HelpTests.cs
@@ -23,15 +23,29 @@ namespace UnitTests
         [TestMethod]
         public void HelpDetected()
         {
-            var oldOut = Console.Out;
-            var stringWriter = new System.IO.StringWriter();
-            Console.SetOut(stringWriter);
-            var result = PowerCommandParser.Parser.ParseArguments<NormalNoHelp>(TestHelper.CmdLineEntryParser("--help"));
-            Console.Out.Flush();
-            Console.SetOut(oldOut);
+            string output;
+            var result = TestHelper.ParseArguments<NormalNoHelp>("--help", out output);
 
             Assert.IsNull(result);
-            Assert.IsFalse(stringWriter.ToString().Contains("No switch named "));
+            Assert.IsFalse(output.Contains("No switch named "));
+        }
+        [TestMethod]
+        public void DoesntParseArguments()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<NormalNoHelp>("-Value one --help -NameSpeltWrong", out output);
+
+            Assert.IsNull(result);
+            Assert.IsFalse(output.Contains("No switch named "));
+            Assert.IsFalse(output.Contains("The value specified for"));
+        }
+        [TestMethod]
+        public void HelpDefaultsToProgramName()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<NormalNoHelp>("--help", out output);
+
+            Assert.IsTrue(output.Contains("UnitTests"));
         }
     }
 }

--- a/UnitTests/HelpTests.cs
+++ b/UnitTests/HelpTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerCommandParser;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,10 +16,19 @@ namespace UnitTests
             public int Value { get; set; }
             public string Name { get; set; }
         }
+        [PowerCommandParser.Description("Sample usage of help attributes")]
         public class ClassWithHelp
         {
             [PowerCommandParser.Description("A name to use")]
             public string Name { get; set; }
+            public int Value { get; set; }
+            [Required]
+            public string Required { get; set; }
+            [Position(1)]
+            public int Positional { get; set; }
+            [Position(2)]
+            [Required]
+            public float PositionalAndRequired { get; set; }
         }
         [TestMethod]
         public void HelpDetected()
@@ -46,6 +56,39 @@ namespace UnitTests
             var result = TestHelper.ParseArguments<NormalNoHelp>("--help", out output);
 
             Assert.IsTrue(output.Contains("UnitTests"));
+        }
+        [TestMethod]
+        public void SynopsisIsUsed()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<ClassWithHelp>("--help", out output);
+
+            Assert.IsTrue(output.Contains("Sample usage of help attributes"));
+            Assert.IsFalse(output.Contains("UnitTests"));
+        }
+        [TestMethod]
+        public void ParamDetailsUsed()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<ClassWithHelp>("--help", out output);
+
+            Assert.IsTrue(output.Contains("A name to use"));
+        }
+        [TestMethod]
+        public void SyntaxIsShown()
+        {
+            string output;
+            var result = TestHelper.ParseArguments<ClassWithHelp>("--help", out output);
+
+            //Assert.IsTrue(output.Contains("UnitTests.exe"));
+            Assert.IsTrue(output.Contains("[Name System.String]"));
+            Assert.IsTrue(output.Contains("[Value System.Int32]"));
+            Assert.IsTrue(output.Contains("Required System.String"));
+            Assert.IsFalse(output.Contains("[Required System.String]"));
+            Assert.IsTrue(output.Contains("[[Positional] System.Int32]"));
+            Assert.IsTrue(output.Contains("[PositionalAndRequired] System.Single"));
+            Assert.IsFalse(output.Contains("[[PositionalAndRequired] System.Single]"));
+            Assert.IsTrue(output.IndexOf("[[Positional] System.Int32]") < output.IndexOf("[PositionalAndRequired] System.Single"));
         }
     }
 }

--- a/UnitTests/ParserTest.cs
+++ b/UnitTests/ParserTest.cs
@@ -34,6 +34,7 @@ namespace UnitTests
             Assert.IsNull(Parser.ParseArguments<BasicUsageOptions>(CmdLineEntryParser("-name \"nathan jervis")));
             Assert.IsNull(Parser.ParseArguments<BasicUsageOptions>(CmdLineEntryParser("-firstname --activate")));
             Assert.IsNull(Parser.ParseArguments<BasicUsageOptions>(CmdLineEntryParser("--name --activate")));
+            Assert.IsNull(Parser.ParseArguments<ComplexTypeSettings>(CmdLineEntryParser("-maxsize dw --activate")));
         }
         class FormatExportOptions
         {

--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -19,5 +19,17 @@ namespace UnitTests
             }
             return pieces.ToArray();
         }
+        public static T ParseArguments<T>(string input, out string output) where T : class, new()
+        {
+            var oldOut = Console.Out;
+            var stringWriter = new System.IO.StringWriter();
+            Console.SetOut(stringWriter);
+            var result = PowerCommandParser.Parser.ParseArguments<T>(TestHelper.CmdLineEntryParser("--help"));
+            Console.Out.Flush();
+            Console.SetOut(oldOut);
+            output = stringWriter.ToString();
+
+            return result;
+        }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -50,6 +50,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="HelpTests.cs" />
     <Compile Include="ListTests.cs" />
     <Compile Include="ParserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Added support for passing in `--help` and getting help text shown. Does not tap into powershell's get-help functionality but that could be added as a future feature enhancement. Resolves #2 
